### PR TITLE
Fix equal size for mobile filter buttons

### DIFF
--- a/src/css/modules/mobile/buttons-mobile.css
+++ b/src/css/modules/mobile/buttons-mobile.css
@@ -154,10 +154,12 @@
 }
 
 #filter-actions-container .btn {
-    flex-basis: 48%;
+    /* Pulsanti azione filtri devono avere dimensioni identiche */
+    flex: 0 0 48%;
+    width: 48%;
+    min-width: unset !important; /* Override min-width desktop */
     text-align: center;
-    
-    /* Reset FORZATO per garantire dimensioni identiche */
+
     padding: 0.5rem 1rem !important;
     font-size: 0.9rem !important;
     line-height: 1.5 !important;


### PR DESCRIPTION
## Summary
- update mobile CSS to ensure `Resetta filtri` and `Esporta CSV` buttons share the same width and height

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecf19cb3c8325adb94d7ebcba499a